### PR TITLE
Fix low randomness in image names

### DIFF
--- a/iform_mobile_auth.module
+++ b/iform_mobile_auth.module
@@ -726,12 +726,14 @@ function iform_mobile_auth_client_submission() {
         // resize.jpg?1333102276814 which will fail the warehouse submission
         // process.
         if (strstr($info['type'], 'jpg') !== FALSE || strstr($info['type'], 'jpeg') !== FALSE) {
-          $info['name'] = sha1(mt_rand(0, 1000000)) . '.jpg';
+          $info['name'] = bin2hex(openssl_random_pseudo_bytes(20)) . '.jpg';
         }
         if (strstr($info['type'], 'png') !== FALSE) {
-          $info['name'] = sha1(mt_rand(0, 1000000)) . '.png';
+          $info['name'] = bin2hex(openssl_random_pseudo_bytes(20)) . '.png';
         }
         $processedFiles[$name] = $info;
+      echo $info['name'];
+
       }
       // Handle files sent along with a species checklist style submission. Files should be POSTed in
       // a field called sc:<gridrow>::photo[1-9+] and will then get moved to the interim image folder and
@@ -739,7 +741,7 @@ function iform_mobile_auth_client_submission() {
       elseif (preg_match('/^sc:(?P<gridrow>.+)::photo(?P<id>[0-9]+)$/', $name, $matches)) {
         $interim_image_folder = isset(data_entry_helper::$interim_image_folder) ? data_entry_helper::$interim_image_folder : 'upload/';
         $uploadPath = data_entry_helper::relative_client_helper_path().$interim_image_folder;
-        $interimFileName = sha1(mt_rand(0, 1000000)) .'.jpg';
+        $interimFileName = bin2hex(openssl_random_pseudo_bytes(20)) .'.jpg';
         if (move_uploaded_file($info['tmp_name'], $uploadPath.$interimFileName)) {
           $_POST["sc:$matches[gridrow]::occurrence_medium:path:$matches[id]"] = $interimFileName;
         }


### PR DESCRIPTION
Image names were generated using a random number 0-1 000 000. For a survey that submits 20K of images would mean it is 1 image name in 50 that will overlap. 