### PR TITLE
Unset user_id when loading a report

### DIFF
--- a/iform_mobile_auth.module
+++ b/iform_mobile_auth.module
@@ -930,6 +930,7 @@ function iform_mobile_auth_report() {
   unset($request['usersecret']);
   unset($request['email']);
   unset($request['cacheTimeout']);
+  unset($request['user_id']);
   $defaults = array(
     'reportSource' => 'local',
   );


### PR DESCRIPTION
Currently, the user can specify its own user_id (hijacking other person's) and run a report with that. The iform_mobile_auth_authorise_request part always passes since it creates a dummy account if no user credentials have been passed.